### PR TITLE
Bump versions and fix logic

### DIFF
--- a/installTerragrunt/task.json
+++ b/installTerragrunt/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "1.95.0",
     "instanceNameFormat": "Install Terragrunt",

--- a/installTerragrunt/task.json
+++ b/installTerragrunt/task.json
@@ -1,45 +1,39 @@
 {
-    "id": "54438fa5-9e77-48ba-bd00-a1a20fd2811b",
-    "name": "Install Terragrunt",
-    "friendlyName": "Install Terragrunt",
-    "description": "Installs terragrunt for Linux, Darwin & Windows",
-    "helpMarkDown": "https://github.com/gruntwork-io/terragrunt",
-    "category": "Tool",
-    "author": "Otacon Engineering",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
-    "runsOn": [
-        "Agent",
-        "DeploymentGroup"
-    ],
-    "version": {
-        "Major": 0,
-        "Minor": 1,
-        "Patch": 1
-    },
-    "minimumAgentVersion": "1.95.0",
-    "instanceNameFormat": "Install Terragrunt",
-    "inputs": [
-        {
-            "name": "terragruntversion",
-            "type": "string",
-            "label": "Version",
-            "defaultValue": "0.25.5",
-            "required": true,
-            "helpMarkDown": "Enter the version of terragrunt to install eg 0.25.5"
-        }
-    ],
-    "satisfies": ["Install Terragrunt"],
-    "demands": [],
-    "execution": {
-        "Node16": {
-            "target": "index.js"
-        }
-    },
-    "repository": {
-        "type": "git",
-        "uri": "https://github.com/ni/terragrunt-azure-dev-ops"
+  "id": "54438fa5-9e77-48ba-bd00-a1a20fd2811b",
+  "name": "Install Terragrunt",
+  "friendlyName": "Install Terragrunt",
+  "description": "Installs terragrunt for Linux, Darwin & Windows",
+  "helpMarkDown": "https://github.com/gruntwork-io/terragrunt",
+  "category": "Tool",
+  "author": "Otacon Engineering",
+  "visibility": ["Build", "Release"],
+  "runsOn": ["Agent", "DeploymentGroup"],
+  "version": {
+    "Major": 0,
+    "Minor": 1,
+    "Patch": 5
+  },
+  "minimumAgentVersion": "1.95.0",
+  "instanceNameFormat": "Install Terragrunt",
+  "inputs": [
+    {
+      "name": "terragruntversion",
+      "type": "string",
+      "label": "Version",
+      "defaultValue": "0.25.5",
+      "required": true,
+      "helpMarkDown": "Enter the version of terragrunt to install eg 0.25.5"
     }
+  ],
+  "satisfies": ["Install Terragrunt"],
+  "demands": [],
+  "execution": {
+    "Node16": {
+      "target": "index.js"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "uri": "https://github.com/ni/terragrunt-azure-dev-ops"
+  }
 }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,44 +1,39 @@
 {
-    "manifestVersion": 1,
-    "id": "Terragrunt",
-    "publisher": "ni",
-    "version": "0.0.10",
-    "name": "Install Terragrunt",
-    "description": "Installs terragrunt",
-    "public": false,
-    "categories": ["Azure Pipelines"],
-    "targets": [
-        {
-            "id": "Microsoft.VisualStudio.Services"
-        }
-    ],
-    "content": {
-        "details": {
-            "path": "README.md"
-        }
-    },
-    "icons": {
-        "default": "images/gruntwork-logo.png"
-    },
-    "contributions": [
-        {
-            "id": "Install Terragrunt",
-            "type": "ms.vss-distributed-task.task",
-            "targets": [
-                "ms.vss-distributed-task.tasks"
-            ],
-            "properties": {
-                "name": "installTerragrunt"
-            }
-        }
-    ],
-    "files": [
-        {"path": "installTerragrunt"}
-    ],
-    "repository": {
-        "type": "git",
-        "uri": "https://github.com/ni/terragrunt-azure-dev-ops"
-    },
-    "links": {
+  "manifestVersion": 1,
+  "id": "Terragrunt",
+  "publisher": "ni",
+  "version": "0.0.15",
+  "name": "Install Terragrunt",
+  "description": "Installs terragrunt",
+  "public": false,
+  "categories": ["Azure Pipelines"],
+  "targets": [
+    {
+      "id": "Microsoft.VisualStudio.Services"
     }
+  ],
+  "content": {
+    "details": {
+      "path": "README.md"
+    }
+  },
+  "icons": {
+    "default": "images/gruntwork-logo.png"
+  },
+  "contributions": [
+    {
+      "id": "Install Terragrunt",
+      "type": "ms.vss-distributed-task.task",
+      "targets": ["ms.vss-distributed-task.tasks"],
+      "properties": {
+        "name": "installTerragrunt"
+      }
+    }
+  ],
+  "files": [{ "path": "installTerragrunt" }],
+  "repository": {
+    "type": "git",
+    "uri": "https://github.com/ni/terragrunt-azure-dev-ops"
+  },
+  "links": {}
 }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "Terragrunt",
     "publisher": "ni",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "name": "Install Terragrunt",
     "description": "Installs terragrunt",
     "public": false,


### PR DESCRIPTION
bump installTerragrunt to 0.1.1
bump package to 0.0.10

I published from my branch and tested until I got the logic working. The other commit represents the updates to the logic (including a silly "terraform" variable that I didn't rename to "terragrunt").

Other format changes were automatic in VSCode with Prettier.